### PR TITLE
no more Meteor.absoluteUrl()

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ if (Meteor.isClient) {
 
    // Finish the upload progress in the session variable
    fc.resumable.on('fileSuccess', function (resFile) {
-      var fileUrl = Meteor.absoluteUrl() + "gridfs/data/id/" + resFile.uniqueIdentifier;
+      var fileUrl = /* JJR Meteor.absoluteUrl()*/'/' + "gridfs/data/id/" + resFile.uniqueIdentifier;
       // console.log("Success!", resFile, fileUrl);
       resFile.file._orionCallbacks.success(fileUrl, { gridFS_id: resFile.uniqueIdentifier } );
       return;


### PR DESCRIPTION
In order to make this package work on different port numbers (when developing localy), AND from different URL's in production, I propose this change:

It makes no mention of the protocol, host or port number, when creating a **orionFiles** and as such the images are accessible from the same base as the web page itself. Exactly what is needed.
